### PR TITLE
Updated orders/shipped and orders/pending (and added empty staff router)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -7,6 +7,7 @@ var logger = require("morgan");
 
 var indexRouter = require("./routes/index");
 var usersRouter = require("./routes/users");
+var staffRouter = require("./routes/staff");
 var authRouter = require("./routes/auth");
 var ordersRouter = require("./routes/orders");
 var itemsRouter = require("./routes/items");
@@ -32,6 +33,7 @@ app.use("/", indexRouter);
 app.use("/auth", authRouter);
 app.use("/items", itemsRouter);
 app.use("/users", usersRouter);
+app.use("/staff", staffRouter);
 app.use("/cart", cartRouter);
 app.use("/orders", ordersRouter);
 

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -155,7 +155,6 @@ router.post("/shipped", (req, res) => {
     console.log("in ship");
     const getQuantities = `SELECT itemId, quantity FROM orders WHERE orderNumber="${req.body.orderNumber}";`;
     connection.query(getQuantities, function(error, results) {
-      //connection.release();
       if (error) {
         console.log(error.message);
         throw error;
@@ -171,7 +170,6 @@ router.post("/shipped", (req, res) => {
       }
       getInventoryStock += ';';
       connection.query(getInventoryStock, function(error, results) {
-        //connection.release();
         if (error) {
           console.log(error.message);
           throw error;
@@ -199,7 +197,6 @@ router.post("/shipped", (req, res) => {
             cur_quantity = results[i].stock - items_needed[i][1];
             var updateStock = `UPDATE items set stock=${cur_quantity} WHERE itemId=${cur_itemId};`;
             connection.query(updateStock, function(error, results) {
-              connection.release();
               if (error) {
                 console.log(error.message);
                 throw error;
@@ -209,7 +206,6 @@ router.post("/shipped", (req, res) => {
           //Update order status
           const shippedString = `UPDATE orders SET status = "shipped" WHERE orderNumber="${req.body.orderNumber}";`;
           connection.query(shippedString, function(error, reuslts) {
-            connection.release();
             if (error) {
               console.log(error.message);
               throw error;
@@ -217,9 +213,9 @@ router.post("/shipped", (req, res) => {
           });
         }
         res.json(items_missing);
-      })
-    })
-  })
-})
+      });
+    });
+  });
+});
 
 module.exports = router;

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -140,7 +140,6 @@ router.post("/pending", (req, res) => {
             }
           });
         }
-        connection.release();
       }
     );
   });
@@ -153,18 +152,50 @@ router.post("/shipped", (req, res) => {
       console.log(err.message);
       throw err;
     }
-    const shippedString = `UPDATE orders SET status = "shipped" WHERE orderNumber="${req.body.orderNumber}";`;
-    connection.query(shippedString, function(error, results) {
-      connection.release();
+    console.log("in ship");
+    const getQuantities = `SELECT itemId, quantity FROM orders WHERE orderNumber="${req.body.orderNumber}";`;
+    connection.query(getQuantities, function(error, results) {
+      //connection.release();
       if (error) {
         console.log(error.message);
         throw error;
-      } else {
-        console.log("Record changed.");
-        res.end();
       }
-    });
-  });
-});
+      var items_needed = [];  
+      for (i = 0; i < results.length; i++) {
+        items_needed.push([results[i].itemId, results[i].quantity]);
+      }
+      console.log(items_needed);
+      var getInventoryStock = `SELECT itemId, stock FROM items WHERE`;
+      for (i = 0; i < results.length; i++) {
+        getInventoryStock += (" itemId=" + items_needed[i][0]);
+      }
+      getInventoryStock += ';';
+      connection.query(getInventoryStock, function(error, results) {
+        //connection.release();
+        if (error) {
+          console.log(error.message);
+          throw error;
+        }
+        var items_missing = [];
+        var cur_index = 0;
+        for (i = 0; i < results.length; i++) {
+          if (results[i].stock < items_needed[i][1]) {
+            items_missing[cur_index][0] = results[i].itemId;
+            items_missing[cur_index][1] = (items_needed[i][1] - results[i].stock);
+            cur_index += 1;
+          }
+        }
+        if (items_missing.length !== 0) {
+          console.log("missing items");
+        }
+        else {
+          console.log("order shipped");
+          //remove items from inventory, change status to shipped
+        }
+        res.json(items_missing);
+      })
+    })
+  })
+})
 
 module.exports = router;

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -174,7 +174,7 @@ router.post("/shipped", (req, res) => {
             cur_quantity = results[i].stock - items_needed[i][1];
             var updateStock = `UPDATE items set stock=${cur_quantity} WHERE itemId=${cur_itemId};`;
             connection.query(updateStock, function(error, results) {
-              connection.release();
+              
               if (error) {
                 console.log(error.message);
                 throw error;
@@ -184,7 +184,7 @@ router.post("/shipped", (req, res) => {
           //Update order status
           const shippedString = `UPDATE orders SET status = "shipped" WHERE orderNumber="${req.body.orderNumber}";`;
           connection.query(shippedString, function(error, reuslts) {
-            connection.release();
+           
             if (error) {
               console.log(error.message);
               throw error;
@@ -194,6 +194,7 @@ router.post("/shipped", (req, res) => {
         res.json(items_missing);
         res.end();
       });
+      connection.release();
     });
   });
 });

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -190,7 +190,31 @@ router.post("/shipped", (req, res) => {
         }
         else {
           console.log("order shipped");
-          //remove items from inventory, change status to shipped
+          var updateStock = ``;
+          var cur_itemId = 0;
+          var cur_quantity = 0;
+          //Remove shipped items from inventory
+          for (i = 0; i < items_needed.length; i++) {
+            cur_itemId = items_needed[i][0];
+            cur_quantity = results[i].stock - items_needed[i][1];
+            var updateStock = `UPDATE items set stock=${cur_quantity} WHERE itemId=${cur_itemId};`;
+            connection.query(updateStock, function(error, results) {
+              connection.release();
+              if (error) {
+                console.log(error.message);
+                throw error;
+              }
+            });
+          }
+          //Update order status
+          const shippedString = `UPDATE orders SET status = "shipped" WHERE orderNumber="${req.body.orderNumber}";`;
+          connection.query(shippedString, function(error, reuslts) {
+            connection.release();
+            if (error) {
+              console.log(error.message);
+              throw error;
+            }
+          });
         }
         res.json(items_missing);
       })

--- a/server/routes/staff.js
+++ b/server/routes/staff.js
@@ -1,0 +1,17 @@
+var express = require("express");
+var mysql = require("mysql");
+
+const pool = mysql.createPool({
+  connectionLimit: 10,
+  host: "localhost",
+  user: "geoffrey",
+  password: "Ya9pQcM3x7BsRqDX",
+  database: "toyzrus"
+});
+
+var router = express.Router();
+
+
+
+
+module.exports = router;

--- a/server/routes/staff.js
+++ b/server/routes/staff.js
@@ -11,56 +11,7 @@ const pool = mysql.createPool({
 
 var router = express.Router();
 
-router.post("/ship", (req, res) => {
-  pool.getConnection((err, connection) => {
-    if (err) {
-      console.log(err.message);
-      throw err;
-    }
-    const getQuantities = `SELECT itemId, quantity FROM orders WHERE orderNumber=${req.body.orderNumber};`;
-    connection.query(getQuantities, function(error, results) {
-      connection.release();
-      if (error) {
-        console.log(error.message);
-        throw error;
-      }
-      var items_needed = [];  
-      for (i = 0; i < results.length; i++) {
-        items_needed[i][0] = results[i].itemId;
-        items_needed[i][1] = results[i].quantity;
-      }
-      var getInventoryStock = `SELECT itemId, stock FROM items WHERE`;
-      for (i = 0; i < results.length; i++) {
-        getInventoryStock += (" " + items_needed[i][0]);
-      }
-      getInventoryStock += ';';
-      connection.query(getInventoryStock, function(error, results) {
-        connection.release();
-        if (error) {
-          console.log(error.message);
-          throw error;
-        }
-        var items_missing = [];
-        var cur_index = 0;
-        for (i = 0; i < results.length; i++) {
-          if (results[i].stock < items_needed[i][1]) {
-            items_missing[cur_index][0] = results[i].itemId;
-            items_missing[cur_index][1] = (items_needed[i][1] - results[i].stock);
-            cur_index += 1;
-          }
-        }
-        if (items_missing.length !== 0) {
-          console.log("missing items");
-        }
-        else {
-          console.log("order shipped");
-          //remove items from inventory, change status to shipped
-        }
-        res.json(items_missing);
-      })
-    })
-  })
-})
+
 
 
 module.exports = router;

--- a/server/routes/staff.js
+++ b/server/routes/staff.js
@@ -11,7 +11,56 @@ const pool = mysql.createPool({
 
 var router = express.Router();
 
-
+router.post("/ship", (req, res) => {
+  pool.getConnection((err, connection) => {
+    if (err) {
+      console.log(err.message);
+      throw err;
+    }
+    const getQuantities = `SELECT itemId, quantity FROM orders WHERE orderNumber=${req.body.orderNumber};`;
+    connection.query(getQuantities, function(error, results) {
+      connection.release();
+      if (error) {
+        console.log(error.message);
+        throw error;
+      }
+      var items_needed = [];  
+      for (i = 0; i < results.length; i++) {
+        items_needed[i][0] = results[i].itemId;
+        items_needed[i][1] = results[i].quantity;
+      }
+      var getInventoryStock = `SELECT itemId, stock FROM items WHERE`;
+      for (i = 0; i < results.length; i++) {
+        getInventoryStock += (" " + items_needed[i][0]);
+      }
+      getInventoryStock += ';';
+      connection.query(getInventoryStock, function(error, results) {
+        connection.release();
+        if (error) {
+          console.log(error.message);
+          throw error;
+        }
+        var items_missing = [];
+        var cur_index = 0;
+        for (i = 0; i < results.length; i++) {
+          if (results[i].stock < items_needed[i][1]) {
+            items_missing[cur_index][0] = results[i].itemId;
+            items_missing[cur_index][1] = (items_needed[i][1] - results[i].stock);
+            cur_index += 1;
+          }
+        }
+        if (items_missing.length !== 0) {
+          console.log("missing items");
+        }
+        else {
+          console.log("order shipped");
+          //remove items from inventory, change status to shipped
+        }
+        res.json(items_missing);
+      })
+    })
+  })
+})
 
 
 module.exports = router;


### PR DESCRIPTION
I removed the inventory interaction in the orders/pending route and added stock checking/updating functionality to orders/shipped. I didn't realize that the pending route had been updated, so it's written differently, but as far as I can tell orders/shipped now does all orders/pending currently does in Master and sends a 2D array containing missing items by res.json. This branch also removes the npm crash for orders containing a higher item quantity than is currently in stock.

